### PR TITLE
Initialize portfolio with main pages

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pablo Torrado - Curr\xC3\xADculum</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Lora:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="index.html">Inicio</a>
+            <a href="curriculum.html" class="active">Curr\xC3\xADculum</a>
+            <a href="proyectos.html">Proyectos</a>
+            <a href="publicaciones.html">Publicaciones</a>
+        </nav>
+    </header>
+    <main class="container">
+        <section class="cv-section">
+            <h2>Resumen Profesional</h2>
+            <p>Profesor de espa\xC3\xB1ol, dise\xC3\xB1ador curricular y examinador DELE con m\xC3\xA1s de una d\xC3\xA9cada de experiencia internacional en Hong Kong, Tailandia y Espa\xC3\xB1a. Especializado en la aplicaci\xC3\xB3n de tecnolog\xC3\xADas (TICS) para la adquisici\xC3\xB3n de l\xC3\xA9xico y la creaci\xC3\xB3n de materiales did\xC3\xA1cticos innovadores.</p>
+        </section>
+        <section class="cv-section">
+            <h2>Experiencia Docente</h2>
+            <ul>
+                <li>Universidad de Hong Kong (2020-24): Profesor de espa\xC3\xB1ol y Coordinador de SPAN1001 y SPAN1002.</li>
+                <li>Universidad Thammasat, Tailandia (Beca LECTOR AECID): Desarrollo de curr\xC3\xADculos y docencia de cursos generales, conversaci\xC3\xB3n, cultura y literatura (1200 horas).</li>
+                <li>Universidad de Khon Kaen, Tailandia (Beca LECTOR AECID): Desarrollo de curr\xC3\xADculos y docencia en gram\xC3\xA1tica, escritura, espa\xC3\xB1ol para negocios y literatura (1200 horas).</li>
+            </ul>
+        </section>
+        <section class="cv-section">
+            <h2>Formaci\xC3\xB3n Acad\xC3\xA9mica</h2>
+            <ul>
+                <li>M\xC3\xA1ster Oficial en Ling\xC3\xBC\xC3\xADstica Aplicada a la Ense\xC3\xB1anza del Espa\xC3\xB1ol como Lengua Extranjera, Universidad Antonio de Nebrija, Madrid (2016).</li>
+                <li>Filolog\xC3\xADa Hisp\xC3\xA1nica, Universidad de Salamanca (2008).</li>
+                <li>Certificado de Aptitud Pedag\xC3\xB3gica (CAP), Universidad de Salamanca.</li>
+            </ul>
+        </section>
+        <section class="cv-section">
+            <h2>Idiomas</h2>
+            <ul>
+                <li>Espa\xC3\xB1ol: Nativo</li>
+                <li>Ingl\xC3\xA9s: C1 - CAE</li>
+                <li>Franc\xC3\xA9s: B1</li>
+                <li>Tailand\xC3\xA9s: B1</li>
+            </ul>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,17 +16,14 @@
             <a href="curriculum.html">Currículum</a>
             <a href="proyectos.html">Proyectos</a>
             <a href="publicaciones.html">Publicaciones</a>
-            <a href="contacto.html">Contacto</a>
         </nav>
     </header>
-    <main class="container">
-        <section class="hero">
-            <img src="URL_DE_TU_FOTO_PROFESIONAL" alt="Pablo Torrado" class="profile-pic">
-            <h1>Pablo Torrado Solo de Zaldívar</h1>
-            <h2>Profesor de Español | Diseñador Curricular | Investigador en Lingüística Aplicada</h2>
-            <p class="intro">Bienvenido a mi laboratorio digital. Aquí encontrarás una combinación de mis proyectos de desarrollo web, mis publicaciones académicas y mi experiencia en la enseñanza del español como lengua extranjera.</p>
-            <a href="proyectos.html" class="cta-button">Ver mis Proyectos</a>
-        </section>
+    <main class="container" style="text-align: center; padding-top: 2rem;">
+        <img src="img/pablo.png" alt="Pablo Torrado" style="width: 150px; height: 150px; border-radius: 50%; border: 5px solid var(--naranja-atomico); object-fit: cover;">
+        <h1 style="font-size: 2.5rem;">Pablo Torrado Solo de Zaldívar</h1>
+        <h2 style="font-weight: normal;">Profesor de Español | Diseñador Curricular | Investigador</h2>
+        <p style="max-width: 600px; margin: 1rem auto;">Bienvenido a mi laboratorio digital. Aquí encontrarás una combinación de mis proyectos de desarrollo, mis publicaciones académicas y mi experiencia en la enseñanza del español.</p>
+        <a href="proyectos.html" style="display: inline-block; background-color: var(--naranja-atomico); color: var(--blanco); padding: 12px 25px; border-radius: 5px; text-decoration: none; font-weight: 700; margin-top: 1.5rem;">Ver mis Proyectos</a>
     </main>
 </body>
 </html>

--- a/proyectos.html
+++ b/proyectos.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pablo Torrado - Proyectos</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Lora:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="index.html">Inicio</a>
+            <a href="curriculum.html">Curr\xC3\xADculum</a>
+            <a href="proyectos.html" class="active">Proyectos</a>
+            <a href="publicaciones.html">Publicaciones</a>
+        </nav>
+    </header>
+    <main class="container">
+        <h2>Proyectos Destacados</h2>
+        <div class="proyectos-grid">
+            <div class="proyecto-card">
+                <img src="img/atun_feliz.png" alt="Juego At\xC3\xBAn Feliz">
+                <h3>At\xC3\xBAn Feliz</h3>
+                <p>Simulaci\xC3\xB3n web del juego de cartas "Happy Salmon", creada con HTML, CSS y JavaScript para una experiencia m\xC3\xB3vil interactiva.</p>
+                <div class="card-links">
+                    <a href="URL_DEMO_ATUN_FELIZ" class="proyecto-btn">Ver Demo</a>
+                    <a href="URL_GITHUB_ATUN_FELIZ" class="proyecto-btn">Ver en GitHub</a>
+                </div>
+            </div>
+            <div class="proyecto-card">
+                <img src="img/icono.png" alt="Icono de portafolio">
+                <h3>Portafolio Personal</h3>
+                <p>Este sitio web. Construido con GitHub Pages para mostrar mi CV, proyectos y publicaciones de forma limpia y profesional.</p>
+                <div class="card-links">
+                    <a href="URL_GITHUB_PORTAFOLIO" class="proyecto-btn">Ver en GitHub</a>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pablo Torrado - Publicaciones</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Lora:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="index.html">Inicio</a>
+            <a href="curriculum.html">Curr\xC3\xADculum</a>
+            <a href="proyectos.html">Proyectos</a>
+            <a href="publicaciones.html" class="active">Publicaciones</a>
+        </nav>
+    </header>
+    <main class="container">
+        <h2>Publicaciones</h2>
+        <p>Contenido en construcci\xC3\xB3n.</p>
+    </main>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -6,73 +6,23 @@
     --font-title: 'Lora', serif;
     --font-body: 'Lato', sans-serif;
 }
+body { font-family: var(--font-body); background-color: var(--gris-claro); color: var(--azul-pizarra); margin: 0; line-height: 1.6; }
+header { background-color: var(--blanco); padding: 1rem 0; box-shadow: 0 2px 5px rgba(0,0,0,0.1); text-align: center; position: sticky; top: 0; z-index: 10; }
+nav a { font-family: var(--font-body); font-weight: 700; color: var(--azul-pizarra); text-decoration: none; margin: 0 1.5rem; padding: 1rem 0; border-bottom: 3px solid transparent; transition: border-color 0.3s; }
+nav a:hover, nav a.active { border-bottom-color: var(--naranja-atomico); }
+.container { max-width: 900px; margin: 2rem auto; padding: 0 1rem; }
+h1, h2, h3 { font-family: var(--font-title); }
 
-body {
-    font-family: var(--font-body);
-    background-color: var(--gris-claro);
-    color: var(--azul-pizarra);
-    margin: 0;
-    line-height: 1.6;
-}
+.cv-section { background-color: var(--blanco); padding: 1.5rem; margin-bottom: 1.5rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+.cv-section h2 { margin-top: 0; border-bottom: 2px solid var(--naranja-atomico); padding-bottom: 0.5rem; }
+.cv-section ul { list-style: none; padding-left: 0; }
+.cv-section li { margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--gris-claro); }
+.cv-section li:last-child { border-bottom: none; }
 
-header {
-    background-color: var(--blanco);
-    padding: 1rem 0;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-    text-align: center;
-}
-
-nav a {
-    font-family: var(--font-body);
-    font-weight: 700;
-    color: var(--azul-pizarra);
-    text-decoration: none;
-    margin: 0 1.5rem;
-    padding-bottom: 5px;
-    border-bottom: 3px solid transparent;
-}
-
-nav a:hover, nav a.active {
-    border-bottom-color: var(--naranja-atomico);
-}
-
-.container {
-    max-width: 900px;
-    margin: 2rem auto;
-    padding: 0 1rem;
-}
-
-.hero {
-    text-align: center;
-    padding: 2rem 0;
-}
-
-.profile-pic {
-    width: 150px;
-    height: 150px;
-    border-radius: 50%;
-    border: 5px solid var(--naranja-atomico);
-    object-fit: cover;
-}
-
-h1 {
-    font-family: var(--font-title);
-    font-size: 2.5rem;
-    margin-bottom: 0.5rem;
-}
-
-.cta-button {
-    display: inline-block;
-    background-color: var(--naranja-atomico);
-    color: var(--blanco);
-    padding: 12px 25px;
-    border-radius: 5px;
-    text-decoration: none;
-    font-weight: 700;
-    margin-top: 1.5rem;
-    transition: transform 0.2s;
-}
-
-.cta-button:hover {
-    transform: translateY(-3px);
-}
+.proyectos-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }
+.proyecto-card { background: var(--blanco); border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); overflow: hidden; display: flex; flex-direction: column; }
+.proyecto-card img { width: 100%; height: 200px; object-fit: cover; }
+.proyecto-card h3 { padding: 1rem 1rem 0 1rem; margin: 0; }
+.proyecto-card p { padding: 0.5rem 1rem; flex-grow: 1; }
+.card-links { padding: 0 1rem 1rem 1rem; }
+.proyecto-btn { text-decoration: none; color: var(--naranja-atomico); font-weight: bold; }


### PR DESCRIPTION
## Summary
- build index page for Pablo Torrado's portfolio
- add curriculum, projects and publications pages
- implement shared navigation and layout styles
- remove placeholder image binaries

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848d75f23548327a76656c2c9493250