### PR TITLE
Fix missing profile picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# pablotorrado
+# Portafolio de Pablo Torrado
+
+Este repositorio contiene los archivos fuente de mi portafolio personal.
+
+![Foto de Pablo Torrado](personalpic.jpg)
+
+Abre `index.html` en tu navegador para explorar mi curr\u00edculo, proyectos y publicaciones.

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         </nav>
     </header>
     <main class="container" style="text-align: center; padding-top: 2rem;">
-        <img src="img/pablo.png" alt="Pablo Torrado" style="width: 150px; height: 150px; border-radius: 50%; border: 5px solid var(--naranja-atomico); object-fit: cover;">
+        <img src="personalpic.jpg" alt="Pablo Torrado" style="width: 150px; height: 150px; border-radius: 50%; border: 5px solid var(--naranja-atomico); object-fit: cover;">
         <h1 style="font-size: 2.5rem;">Pablo Torrado Solo de Zaldívar</h1>
         <h2 style="font-weight: normal;">Profesor de Español | Diseñador Curricular | Investigador</h2>
         <p style="max-width: 600px; margin: 1rem auto;">Bienvenido a mi laboratorio digital. Aquí encontrarás una combinación de mis proyectos de desarrollo, mis publicaciones académicas y mi experiencia en la enseñanza del español.</p>


### PR DESCRIPTION
## Summary
- replace missing `img/pablo.png` with `personalpic.jpg`
- clean up README and embed the personal photo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848da4eae548327bc0caeeb2f1aba49