### PR TITLE
Set Playfair Display as main body font

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css">
 
     <link rel="icon" href="imagenes/favicon.png" type="image/png">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
 
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">

--- a/curriculum.html
+++ b/curriculum.html
@@ -7,7 +7,7 @@
     <title>Currículum - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@400;700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Inicio - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@400;700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
 </head>

--- a/proyectos.html
+++ b/proyectos.html
@@ -8,11 +8,7 @@
 
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="imagenes/favicon.png" type="image/png">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
-
-
-    <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@400;700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
     <style>
@@ -108,12 +104,8 @@
             }
         }
 
-        @font-face {
-            font-family: 'PixelSerif';
-            src: url('fonts/PixelSerif_16px_v02.otf') format('opentype');
-        }
         body {
-            font-family: 'PixelSerif', var(--font-body);
+            font-family: var(--font-body);
         }
 
     </style>

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -7,7 +7,7 @@
     <title>Publicaciones - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@400;700&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
 </head>

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@
     --naranja-atomico: #ff6b6b;
     --sombra: rgba(0, 0, 0, 0.08);
     --font-title: 'Playfair Display', serif;
-    --font-body: 'Montserrat', sans-serif;
+    --font-body: 'Playfair Display', serif;
 }
 
 body {


### PR DESCRIPTION
## Summary
- use Playfair Display as the body font in `style.css`
- load weights 400 and 700 for Playfair Display in HTML headers
- remove `PixelSerif` usage from `proyectos.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849009d9d188327a9884fd6f78bc9f6