### PR TITLE
Reduce sidebar profile photo size

### DIFF
--- a/style.css
+++ b/style.css
@@ -379,7 +379,8 @@ Estilos Mejorados para la Barra de Navegaci\u00f3n Lateral
   padding-bottom: 20px; /* Borde m\u00e1s grueso abajo, estilo polaroid */
   background: white;
   box-shadow: 0 5px 15px rgba(0,0,0,0.2);
-  width: 140px;
+  /* Drastically reduce the sidebar photo size */
+  width: 45px; /* original 140px -> reduced over 65% */
   transform: rotate(-4deg); /* Ligeramente ladeado */
   transition: all 0.3s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- drastically shrink the sidebar profile picture in the polaroid frame by over 65%

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493cf0e6ec83278e00cb6082a83909