### PR TITLE
Restore language switch button

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -38,6 +38,7 @@
                 <li class="active"><a href="curriculum.html"><i class="fas fa-file-alt"></i> <span>Currículum</span></a></li>
                 <li><a href="proyectos.html"><i class="fas fa-laptop-code"></i> <span>Proyectos</span></a></li>
                 <li><a href="publicaciones.html"><i class="fas fa-book-open"></i> <span>Publicaciones</span></a></li>
+                <li><button id="lang-btn" class="lang-toggle">English version</button></li>
             </ul>
         </nav>
     </div>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
                 <li><a href="curriculum.html"><i class="fas fa-file-alt"></i> <span>Currículum</span></a></li>
                 <li><a href="proyectos.html"><i class="fas fa-laptop-code"></i> <span>Proyectos</span></a></li>
                 <li><a href="publicaciones.html"><i class="fas fa-book-open"></i> <span>Publicaciones</span></a></li>
+                <li><button id="lang-btn" class="lang-toggle">English version</button></li>
             </ul>
         </nav>
     </div>

--- a/lang-toggle.js
+++ b/lang-toggle.js
@@ -3,6 +3,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const langBtn = document.getElementById('lang-btn');
   if (langBtn) {
+    const current = document.documentElement.getAttribute('lang') || 'es';
+    langBtn.textContent = current === 'es' ? 'English version' : 'En español';
     langBtn.addEventListener('click', toggleLanguage);
   }
 

--- a/proyectos.html
+++ b/proyectos.html
@@ -141,6 +141,7 @@
                 <li><a href="curriculum.html"><i class="fas fa-file-alt"></i> <span>Currículum</span></a></li>
                 <li class="active"><a href="proyectos.html"><i class="fas fa-laptop-code"></i> <span>Proyectos</span></a></li>
                 <li><a href="publicaciones.html"><i class="fas fa-book-open"></i> <span>Publicaciones</span></a></li>
+                <li><button id="lang-btn" class="lang-toggle">English version</button></li>
             </ul>
         </nav>
     </div>

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -35,6 +35,7 @@
                 <li><a href="curriculum.html"><i class="fas fa-file-alt"></i> <span>Currículum</span></a></li>
                 <li><a href="proyectos.html"><i class="fas fa-laptop-code"></i> <span>Proyectos</span></a></li>
                 <li class="active"><a href="publicaciones.html"><i class="fas fa-book-open"></i> <span>Publicaciones</span></a></li>
+                <li><button id="lang-btn" class="lang-toggle">English version</button></li>
             </ul>
         </nav>
     </div>

--- a/style.css
+++ b/style.css
@@ -460,6 +460,25 @@ Estilos Mejorados para la Barra de Navegaci\u00f3n Lateral
   border-radius: 5px;
 }
 
+.nav-menu button.lang-toggle {
+  width: 100%;
+  background: none;
+  border: none;
+  color: #a8b9c9;
+  padding: 12px 15px;
+  margin-bottom: 8px;
+  text-align: left;
+  font-size: 15px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border-radius: 5px;
+}
+
+.nav-menu button.lang-toggle:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
 .nav-menu a i {
   font-size: 20px; /* Iconos un poco m\u00e1s peque\u00f1os */
   padding-right: 10px;


### PR DESCRIPTION
## Summary
- restore toggle to show English/Spanish version button
- style language button in sidebar navigation
- display English/Spanish version button on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68494170dddc83278dd92c6ac750fdf3