### PR TITLE
Fix project titles in bilingual page

### DIFF
--- a/proyectos.html
+++ b/proyectos.html
@@ -187,7 +187,7 @@
 
             <div class="project-card">
                 <div class="project-info">
-                    <h3 data-en="Happy Tuna">Atún Feliz</h3>
+                    <h3 data-en="Atún Feliz">Atún Feliz</h3>
                     <p data-en="A digital adaptation of the card game Happy Salmon, created for educational purposes to practice vocabulary and reflexes.">Adaptación digital del juego de cartas Happy Salmon, creado con fines educativos para practicar vocabulario y reflejos.</p>
                     <a href="https://balpomorelitm.github.io/atunfeliz/" class="cta-button" target="_blank" data-en="Play →">Jugar &rarr;</a>
                 </div>
@@ -198,7 +198,7 @@
 
             <div class="project-card">
                 <div class="project-info">
-                    <h3 data-en="Keywords">Palabras Clave</h3>
+                    <h3 data-en="Palabras Clave">Palabras Clave</h3>
                     <p data-en="A secret code-style game for Spanish students using the CVC word bank (Level A1-A2).">Juego tipo código secreto para estudiantes de español con el banco de palabras del CVC (Nivel A1-A2).</p>
                     <a href="https://balpomorelitm.github.io/Codigos-secretos/" class="cta-button" target="_blank" data-en="Play →">Jugar &rarr;</a>
                 </div>
@@ -209,7 +209,7 @@
 
             <div class="project-card">
                 <div class="project-info">
-                    <h3 data-en="Good Notes">#BuenasNotas</h3>
+                    <h3 data-en="#BuenasNotas">#BuenasNotas</h3>
                     <p data-en="A \"pretty notes\" contest organized in Bangkok (2020) to encourage creativity in learning Spanish, with notes in English and Thai.">
                         Un concurso de "apuntes bonitos" organizado en Bangkok (2020) para fomentar la creatividad en el aprendizaje del español, con notas en inglés y tailandés.
                     </p>


### PR DESCRIPTION
## Summary
- keep "Atún Feliz", "Palabras Clave" and `#BuenasNotas` titles unchanged when switching languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849517ac4588327a8571d33bd3cff82