### PR TITLE
Remove LinkedIn icon and restore email emoji

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -25,8 +25,7 @@
                 <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
 
                 <div class="social-links text-center">
-                    <a href="mailto:pablot@hku.hk" class="email"><i class="fas fa-envelope"></i></a>
-                    <a href="https://www.linkedin.com/in/pablotorradosolo" target="_blank" class="linkedin"><i class="fab fa-linkedin-in"></i></a>
+                    <a href="mailto:pablot@hku.hk" class="email">📧</a>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -22,8 +22,7 @@
                 <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
                 
                 <div class="social-links text-center">
-                    <a href="mailto:pablot@hku.hk" class="email"><i class="fas fa-envelope"></i></a>
-                    <a href="https://www.linkedin.com/in/pablotorradosolo" target="_blank" class="linkedin"><i class="fab fa-linkedin-in"></i></a>
+                    <a href="mailto:pablot@hku.hk" class="email">📧</a>
                 </div>
             </div>
 

--- a/proyectos.html
+++ b/proyectos.html
@@ -128,8 +128,7 @@
                 <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
 
                 <div class="social-links text-center">
-                    <a href="mailto:pablot@hku.hk" class="email"><i class="fas fa-envelope"></i></a>
-                    <a href="https://www.linkedin.com/in/pablotorradosolo" target="_blank" class="linkedin"><i class="fab fa-linkedin-in"></i></a>
+                    <a href="mailto:pablot@hku.hk" class="email">📧</a>
                 </div>
             </div>
 

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -22,8 +22,7 @@
                 <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
 
                 <div class="social-links text-center">
-                    <a href="mailto:pablot@hku.hk" class="email"><i class="fas fa-envelope"></i></a>
-                    <a href="https://www.linkedin.com/in/pablotorradosolo" target="_blank" class="linkedin"><i class="fab fa-linkedin-in"></i></a>
+                    <a href="mailto:pablot@hku.hk" class="email">📧</a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- use the 📧 emoji for the email link beneath the header name
- drop the LinkedIn link from the header

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849535a77ec8327bd7426d5af591e63