### PR TITLE
Fix white typewriter text across all pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -652,6 +652,7 @@ Main Content Wrapper
   font-family: 'Source Code Pro', monospace; /* Console-style font */
   font-size: 2.5rem; /* Much larger font size */
   font-weight: 500;
+  color: var(--blanco);
 }
 
 /* Blinking cursor effect for the typewriter */


### PR DESCRIPTION
## Summary
- enforce white font color for the typed text in the sticky header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849550610b483278449a7d70349e6e4