### PR TITLE
Apply Jersey 15 font to sidebar

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -7,7 +7,7 @@
     <title data-en="Resume - Pablo Torrado">Currículum - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&family=Jersey+15&family=Barrio&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Gochi+Hand&family=Special+Elite&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Inicio - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&family=Jersey+15&family=Barrio&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
 </head>

--- a/proyectos.html
+++ b/proyectos.html
@@ -8,11 +8,11 @@
 
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="imagenes/favicon.png" type="image/png">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Jersey+15&family=Barrio&display=swap" rel="stylesheet">
 
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&family=Jersey+15&family=Barrio&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
     <style>

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -7,7 +7,7 @@
     <title>Publicaciones - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&family=Jersey+15&family=Barrio&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/e396b3a936.js" crossorigin="anonymous"></script>
     <link rel="icon" type="image/png" href="imagenes/favicon.png">
 </head>

--- a/style.css
+++ b/style.css
@@ -361,6 +361,7 @@ Estilos Mejorados para la Barra de Navegaci\u00f3n Lateral
   z-index: 9997;
   padding: 0 15px;
   background: var(--azul-pizarra);
+  font-family: 'Jersey 15', cursive;
   overflow-y: auto;
 }
 
@@ -415,7 +416,7 @@ Estilos Mejorados para la Barra de Navegaci\u00f3n Lateral
   padding: 0;
   font-weight: 600;
   text-align: center;
-  font-family: var(--font-title);
+  font-family: 'Barrio', cursive;
 }
 
 #header .profile h1 a {
@@ -461,7 +462,7 @@ Sidebar Refinements: Social Links & Language Switcher
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: Montserrat, sans-serif;
+  font-family: 'Jersey 15', cursive;
   font-weight: 700;
   font-size: 14px;
   border: 2px solid #5a6d7e;
@@ -527,10 +528,7 @@ body.lang-en-active .lang-es {
   transition: all 0.3s ease; /* Transici\u00f3n suave */
   font-size: 15px;
   border-radius: 5px;
-}
-
-  color: #fff;
-  background: rgba(255, 255, 255, 0.1);
+  text-decoration: none;
 }
 
 .nav-menu a i {


### PR DESCRIPTION
## Summary
- add Google fonts Jersey 15 and Barrio to all pages
- use Jersey 15 across sidebar, keep name in Barrio
- remove underline from sidebar links

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ce69c5c832781fd5aa7346b3d62