### PR TITLE
Update link to university profile

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -22,7 +22,7 @@
 
             <div class="profile">
                 <img src="imagenes/pixelpic.webp" alt="Pablo Torrado" class="img-fluid profile-picture">
-                <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
+                <h1 class="text-light"><a href="https://www.web.smlc.hku.hk/teachingstaff/torrado-solo-de-zaldivar-pablo">Pablo Torrado</a></h1>
 
                 <div class="social-links text-center">
                     <a href="mailto:pablot@hku.hk" class="email">📧</a>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
             <div class="profile">
                 <img src="imagenes/pixelpic.webp" alt="Pablo Torrado" class="img-fluid profile-picture">
-                <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
+                <h1 class="text-light"><a href="https://www.web.smlc.hku.hk/teachingstaff/torrado-solo-de-zaldivar-pablo">Pablo Torrado</a></h1>
                 
                 <div class="social-links text-center">
                     <a href="mailto:pablot@hku.hk" class="email">📧</a>

--- a/proyectos.html
+++ b/proyectos.html
@@ -125,7 +125,7 @@
 
             <div class="profile">
                 <img src="imagenes/pixelpic.webp" alt="Pablo Torrado" class="img-fluid profile-picture">
-                <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
+                <h1 class="text-light"><a href="https://www.web.smlc.hku.hk/teachingstaff/torrado-solo-de-zaldivar-pablo">Pablo Torrado</a></h1>
 
                 <div class="social-links text-center">
                     <a href="mailto:pablot@hku.hk" class="email">📧</a>

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -19,7 +19,7 @@
 
             <div class="profile">
                 <img src="imagenes/pixelpic.webp" alt="Pablo Torrado" class="img-fluid profile-picture">
-                <h1 class="text-light"><a href="index.html">Pablo Torrado</a></h1>
+                <h1 class="text-light"><a href="https://www.web.smlc.hku.hk/teachingstaff/torrado-solo-de-zaldivar-pablo">Pablo Torrado</a></h1>
 
                 <div class="social-links text-center">
                     <a href="mailto:pablot@hku.hk" class="email">📧</a>


### PR DESCRIPTION
## Summary
- change the site header name link to point to the HKU teaching staff profile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a317859708327a478c3cc64bf3025