### PR TITLE
Fix capitalization of "Sobre mí" site-wide

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -35,7 +35,7 @@
                     <li class="lang-es"><a href="curriculum.html"><span>Currículum</span></a></li>
                     <li class="lang-es"><a href="proyectos.html"><span>Proyectos</span></a></li>
                     <li class="lang-es"><a href="publicaciones.html"><span>Publicaciones</span></a></li>
-                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre Mí</span></a></li>
+                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre mí</span></a></li>
                     
                     <li class="lang-en"><a href="index.html"><span>Home</span></a></li>
                     <li class="lang-en"><a href="curriculum.html"><span>Resume</span></a></li>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                     <li class="lang-es"><a href="curriculum.html"><span>Currículum</span></a></li>
                     <li class="lang-es"><a href="proyectos.html"><span>Proyectos</span></a></li>
                     <li class="lang-es"><a href="publicaciones.html"><span>Publicaciones</span></a></li>
-                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre Mí</span></a></li>
+                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre mí</span></a></li>
                     
                     <li class="lang-en"><a href="index.html"><span>Home</span></a></li>
                     <li class="lang-en"><a href="curriculum.html"><span>Resume</span></a></li>
@@ -111,7 +111,7 @@
     <a href="sobre-mi.html" class="photo-card">
         <div class="clothespin"></div>
         <img src="imagenes/drawing.webp" alt="Ilustración personal">
-        <div class="caption"><h3>Sobre Mí</h3></div>
+        <div class="caption"><h3>Sobre mí</h3></div>
     </a>
 
     <a href="proyectos.html" class="photo-card">

--- a/proyectos.html
+++ b/proyectos.html
@@ -143,7 +143,7 @@
                     <li class="lang-es"><a href="curriculum.html"><span>Currículum</span></a></li>
                     <li class="lang-es"><a href="proyectos.html"><span>Proyectos</span></a></li>
                     <li class="lang-es"><a href="publicaciones.html"><span>Publicaciones</span></a></li>
-                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre Mí</span></a></li>
+                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre mí</span></a></li>
                     
                     <li class="lang-en"><a href="index.html"><span>Home</span></a></li>
                     <li class="lang-en"><a href="curriculum.html"><span>Resume</span></a></li>

--- a/publicaciones.html
+++ b/publicaciones.html
@@ -32,7 +32,7 @@
                     <li class="lang-es"><a href="curriculum.html"><span>Currículum</span></a></li>
                     <li class="lang-es"><a href="proyectos.html"><span>Proyectos</span></a></li>
                     <li class="lang-es"><a href="publicaciones.html"><span>Publicaciones</span></a></li>
-                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre Mí</span></a></li>
+                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre mí</span></a></li>
                     
                     <li class="lang-en"><a href="index.html"><span>Home</span></a></li>
                     <li class="lang-en"><a href="curriculum.html"><span>Resume</span></a></li>

--- a/sobre-mi.html
+++ b/sobre-mi.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
-    <title data-en="About Me - Pablo Torrado">Sobre Mí - Pablo Torrado</title>
+    <title data-en="About Me - Pablo Torrado">Sobre mí - Pablo Torrado</title>
 
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Playfair+Display:wght@700&family=Source+Code+Pro:wght@500&family=Work+Sans:wght@400;700&family=Jersey+15&family=Barrio&display=swap" rel="stylesheet">
@@ -89,7 +89,7 @@
                     <li class="lang-es"><a href="curriculum.html"><span>Currículum</span></a></li>
                     <li class="lang-es"><a href="proyectos.html"><span>Proyectos</span></a></li>
                     <li class="lang-es"><a href="publicaciones.html"><span>Publicaciones</span></a></li>
-                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre Mí</span></a></li>
+                    <li class="lang-es"><a href="sobre-mi.html"><span>Sobre mí</span></a></li>
                     
                     <li class="lang-en"><a href="index.html"><span>Home</span></a></li>
                     <li class="lang-en"><a href="curriculum.html"><span>Resume</span></a></li>
@@ -118,7 +118,7 @@
 
     <main id="main">
         <div class="main-header">
-            <h1><span class="typed" data-typed-items="Sobre Mí, Personal, Hobbies, Sobre Mí" data-en="About Me"></span></h1>
+            <h1><span class="typed" data-typed-items="Sobre mí, Personal, Hobbies, Sobre mí" data-en="About Me"></span></h1>
         </div>
 
         <div class="content-wrapper">


### PR DESCRIPTION
## Summary
- adjust the navigation and page headers to use lowercase **mí** in "Sobre mí"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a917944cc8327b8326e11287a9bdf